### PR TITLE
WIP: Adjust tracks to chords

### DIFF
--- a/MusicLib/CMakeLists.txt
+++ b/MusicLib/CMakeLists.txt
@@ -14,6 +14,7 @@ SET( MUSICLIB_SRCS
 	Processors/transposeProcessor.cpp
 	Functions/appendTrackFunction.cpp
 	Functions/fingeredChordsFunction.cpp
+	Functions/fitToChordFunction.cpp
 	Functions/mapChordsFunction.cpp
 	Functions/excerptFunction.cpp
 	Functions/repeatFunction.cpp

--- a/MusicLib/Functions/fingeredChordsFunction.cpp
+++ b/MusicLib/Functions/fingeredChordsFunction.cpp
@@ -52,6 +52,8 @@ namespace {
     const auto recognizedIntervals = std::to_array<IntervalSetToChordType>({
         // clang-format off
         // This must be sorted (the alphabetic sort of a typical editor will work to keep this sorted).
+        //    CBAAGGFFEDDCC
+        //      # # #  # #
         {0b0000000000000111, s_cancelChord},
         {0b0000000000001101, bw_music::ChordType::Value::m9},
         {0b0000000000010101, bw_music::ChordType::Value::M9},

--- a/MusicLib/Functions/fingeredChordsFunction.cpp
+++ b/MusicLib/Functions/fingeredChordsFunction.cpp
@@ -49,7 +49,7 @@ namespace {
     // The "fingered chords" of many arranger-style keyboards are supported, although the root note is always required.
     // The fingering 0b0000100001010001 is ambiguous between M7b5 and M7s11. The latter has a few alternatives, so the former
     // is used.
-    const std::array<IntervalSetToChordType, 63> recognizedIntervals = {{
+    const auto recognizedIntervals = std::to_array<IntervalSetToChordType>({
         // clang-format off
         // This must be sorted (the alphabetic sort of a typical editor will work to keep this sorted).
         {0b0000000000000111, s_cancelChord},
@@ -67,10 +67,12 @@ namespace {
         {0b0000000010101001, bw_music::ChordType::Value::m7_11},
         {0b0000000010101101, bw_music::ChordType::Value::m7_11},
         {0b0000000100010001, bw_music::ChordType::Value::aug},
+        {0b0000001000001101, bw_music::ChordType::Value::m6_9},
         {0b0000001000010101, bw_music::ChordType::Value::M6_9},
         {0b0000001001001001, bw_music::ChordType::Value::dim7},
         {0b0000001010000001, bw_music::ChordType::Value::M6},
         {0b0000001010001001, bw_music::ChordType::Value::m6},
+        {0b0000001010001101, bw_music::ChordType::Value::m6_9},
         {0b0000001010010001, bw_music::ChordType::Value::M6},
         {0b0000001010010101, bw_music::ChordType::Value::M6_9},
         {0b0000010000001001, bw_music::ChordType::Value::m7},
@@ -116,7 +118,7 @@ namespace {
         {0b0000100100010001, bw_music::ChordType::Value::Mj7aug},
         {0b0001000000000001, bw_music::ChordType::Value::_1p8},
         // clang-format on
-    }};
+    });
 
     /// Try to identify a chord type which matches the interval.
     /// Returns a ChordType::Value or -1 for cancel chord.

--- a/MusicLib/Functions/fitToChordFunction.cpp
+++ b/MusicLib/Functions/fitToChordFunction.cpp
@@ -1,0 +1,159 @@
+/**
+ * Function which creates tracks of chord events from tracks of note events.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <MusicLib/Functions/fitToChordFunction.hpp>
+
+#include <MusicLib/Types/Track/TrackEvents/noteEvents.hpp>
+#include <MusicLib/Types/Track/trackBuilder.hpp>
+#include <MusicLib/chord.hpp>
+
+#include <map>
+
+namespace {
+    template <typename T> int sgn(T val) {
+        return (T(0) < val) - (val < T(0));
+    }
+
+    using DegreeAdjustment = std::map<unsigned int, int>;
+    using ChordDegreeAdjustments = std::map<bw_music::ChordType::Value, DegreeAdjustment>;
+
+    const ChordDegreeAdjustments chordDegreeAdjustments = {
+        // How each chord requires and/or modifies certain degrees of the scale.
+        // The adjustments are in semitones.
+        {bw_music::ChordType::Value::M, {{3, 0}}},
+        {bw_music::ChordType::Value::M6, {{3, 0}, {6, 0}}},
+        {bw_music::ChordType::Value::M7, {{3, 0}, {7, 0}}},
+        {bw_music::ChordType::Value::M7s11, {{3, 0}, {7, 0}, {11, 1}}},
+        {bw_music::ChordType::Value::M9, {{3, 0}, {9, 0}}},
+        {bw_music::ChordType::Value::M7_9, {{3, 0}, {7, 0}, {9, 0}}},
+        {bw_music::ChordType::Value::M6_9, {{3, 0}, {6, 0}, {9, 0}}},
+        {bw_music::ChordType::Value::aug, {{3, 0}, {5, 1}}},
+        {bw_music::ChordType::Value::m, {{3, -1}}},
+        {bw_music::ChordType::Value::m6, {{3, -1}, {6, 0}}},
+        {bw_music::ChordType::Value::m7, {{3, -1}, {7, -1}}},
+        {bw_music::ChordType::Value::m7b5, {{3, -1}, {5, -1}, {7, -1}}},
+        {bw_music::ChordType::Value::m9, {{3, -1}, {9, 0}}},
+        {bw_music::ChordType::Value::m7_9, {{3, -1}, {7, -1}, {9, 0}}},
+        {bw_music::ChordType::Value::m7_11, {{3, -1}, {7, -1}, {11, 0}}},
+        {bw_music::ChordType::Value::mM7, {{3, -1}, {7, 0}}},
+        {bw_music::ChordType::Value::mM7_9, {{3, -1}, {7, 0}, {9, 0}}},
+        {bw_music::ChordType::Value::dim, {{3, -1}, {5, -1}}},
+        {bw_music::ChordType::Value::dim7, {{3, -1}, {7, -2}}},
+        {bw_music::ChordType::Value::_7, {{3, 0}, {7, -1}}},
+        {bw_music::ChordType::Value::_7sus4, {{3, 1}, {7, -1}}},
+        {bw_music::ChordType::Value::_7b5, {{3, 0}, {5, -1}, {7, -1}}},
+        {bw_music::ChordType::Value::_79, {{3, 0}, {7, -1}, {9, 0}}},
+        {bw_music::ChordType::Value::_7s11, {{3, 0}, {7, -1}, {11, 1}}},
+        {bw_music::ChordType::Value::_7_13, {{3, 0}, {7, -1}, {13, 0}}},
+        {bw_music::ChordType::Value::_7b9, {{3, 0}, {7, -1}, {9, -1}}},
+        {bw_music::ChordType::Value::_7b13, {{3, 0}, {7, -1}, {13, -1}}},
+        {bw_music::ChordType::Value::_7s9, {{3, 0}, {7, -1}, {9, 1}}},
+        {bw_music::ChordType::Value::Mj7aug, {}},
+        {bw_music::ChordType::Value::_7aug, {{3, 0}, {5, 1}, {7, -1}}},
+        {bw_music::ChordType::Value::_1p8, {}}, // TODO Unsure how to handle this. For now, it is a no-op.
+        {bw_music::ChordType::Value::_1p5, {}}, // TODO Unsure how to handle this. For now, it is a no-op.
+        {bw_music::ChordType::Value::sus4, {{3, 1}}},
+        {bw_music::ChordType::Value::_1p2p5, {{3, -2}}},
+        {bw_music::ChordType::Value::b5, {{5, -1}}},
+        {bw_music::ChordType::Value::mM7b5, {{3, -1}, {5, -1}, {7, 0}}},
+        {bw_music::ChordType::Value::m6_9, {{3, -1}, {6, 0}, {9, 0}}}};
+
+    // Note    C  C# D  D# E  F  F# G  G# A  A# B
+    // Degree  1     2     3  4     5     6     7
+    // Degree  8     9    10 11    12    13    14
+    // Index   0  1  2  3  4  5  6  7  8  9 10 11
+    const std::array<unsigned int, 14> degreeToPitchIndex = {0, 2, 4, 5, 7, 9, 11, 0, 2, 4, 5, 7, 9, 11};
+
+    // Some chromatic notes are adjusted by default, if they have not be otherwise adjusted by the algorithm.
+    // 99 is just a sentinel used for assertions.
+    const std::array<unsigned int, 12> defaultChromaticPitchMap = {99, 0, 99, 3, 99, 99, 7, 99, 7, 99, 10, 99};
+
+    using PitchIndexMap = std::array<unsigned int, 12>;
+
+    PitchIndexMap getPitchIndexMap(bw_music::ChordType::Value chordType) {
+        using GravityMap = std::array<int, 12>;
+        GravityMap gravityMap{};
+
+        PitchIndexMap pitchIndexMap = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+        // Apply adjustments from the modifiers
+        const auto& adjustments = chordDegreeAdjustments.at(chordType);
+        for (const auto& [degree, adjustment] : adjustments) {
+            assert(degree < degreeToPitchIndex.size() && "Degree out of range");
+            const unsigned int sourcePitchIndex = degreeToPitchIndex[degree];
+            assert(sourcePitchIndex < pitchIndexMap.size() && "Pitch class out of range");
+            const unsigned int targetPitchIndex = sourcePitchIndex + adjustment;
+            assert(targetPitchIndex < pitchIndexMap.size() && "Target pitch class out of range");
+            pitchIndexMap[sourcePitchIndex] = targetPitchIndex;
+            gravityMap[targetPitchIndex] = 1;
+            for (unsigned int index = sourcePitchIndex; index != targetPitchIndex; index += sgn(adjustment)) {
+                pitchIndexMap[sourcePitchIndex] = targetPitchIndex;
+                gravityMap[index] = -1;
+            }
+        }
+        // For remaining chromatic notes, if either neighbouring note is a target of a modifier, pull it towards the
+        // target.
+        const std::array<unsigned int, 5> chromaticPitchIndices = {1, 3, 6, 8, 10};
+        for (unsigned int index : chromaticPitchIndices) {
+            if (gravityMap[index] == 0) {
+                // If this note is not a target, check its neighbours.
+                const unsigned int leftNeighbour = (index + 11) % 12;
+                const unsigned int rightNeighbour = (index + 1) % 12;
+                if (gravityMap[leftNeighbour] > 0 || gravityMap[rightNeighbour] > 0) {
+                    // If either neighbour is a target, pull this note towards the nearest target.
+                    // This is left-biased, but I don't think it matters much.
+                    pitchIndexMap[index] = (gravityMap[leftNeighbour] > gravityMap[rightNeighbour]) ? leftNeighbour
+                                                                                                      : rightNeighbour;
+                }
+                else {
+                    // TODO Provide a policy so the user can opt out of this behaviour.
+                    // If neither neighbour is a target, use the default chromatic pitch map.
+                    pitchIndexMap[index] = defaultChromaticPitchMap[index];
+                    assert(pitchIndexMap[index] < 12 && "Default chromatic pitch index out of range");
+                }
+            }
+        }
+
+        return pitchIndexMap;
+    }
+
+    struct PitchMap {
+        PitchMap(bw_music::ChordType::Value chordType) : m_pitchIndexMap(getPitchIndexMap(chordType)) {}
+
+        bw_music::Pitch operator()(bw_music::Pitch pitch) const {
+            // Map the pitch to the corresponding index in the chord.
+            auto [octave, pitchIndex] = std::div(pitch, 12);
+            const unsigned int mappedIndex = m_pitchIndexMap[pitchIndex];
+            assert(mappedIndex < 12 && "Mapped index out of range");
+            return static_cast<bw_music::Pitch>((octave * 12) + mappedIndex);
+        }
+
+        PitchIndexMap m_pitchIndexMap;
+
+    };
+
+} // namespace
+
+bw_music::Track bw_music::fitToChordFunction(const Track& sourceTrack, const Chord& chord) {
+    TrackBuilder resultTrack;
+
+    const PitchMap pitchMap(chord.m_chordType);
+
+    // Iterate through the source track and adjust each note to fit the chord.
+    for (const auto& event : sourceTrack) {
+        if (const auto note = event.as<NoteEvent>()) {
+            TrackEventHolder newNote = *note;
+            newNote->is<NoteEvent>().setPitch(pitchMap(note->getPitch()));
+            resultTrack.addEvent(newNote.release());
+        } else {
+            // If the event is not a NoteEvent, just copy it to the result track.
+            resultTrack.addEvent(event);
+        }
+    }
+
+    return resultTrack.finishAndGetTrack(sourceTrack.getDuration());
+}

--- a/MusicLib/Functions/fitToChordFunction.cpp
+++ b/MusicLib/Functions/fitToChordFunction.cpp
@@ -23,6 +23,7 @@ namespace {
 
     const ChordDegreeAdjustments chordDegreeAdjustments = {
         // How each chord requires and/or modifies certain degrees of the scale.
+        // Degree 1 and 5 don't need to be specified if default.
         // The adjustments are in semitones.
         {bw_music::ChordType::Value::M, {{3, 0}}},
         {bw_music::ChordType::Value::M6, {{3, 0}, {6, 0}}},
@@ -57,7 +58,7 @@ namespace {
         {bw_music::ChordType::Value::_1p8, {}}, // TODO Unsure how to handle this. For now, it is a no-op.
         {bw_music::ChordType::Value::_1p5, {}}, // TODO Unsure how to handle this. For now, it is a no-op.
         {bw_music::ChordType::Value::sus4, {{3, 1}}},
-        {bw_music::ChordType::Value::_1p2p5, {{3, -2}}},
+        {bw_music::ChordType::Value::_1p2p5, {{3, -2}}}, // Assuming this should be interpreted as a sus2 chord.
         {bw_music::ChordType::Value::b5, {{5, -1}}},
         {bw_music::ChordType::Value::mM7b5, {{3, -1}, {5, -1}, {7, 0}}},
         {bw_music::ChordType::Value::m6_9, {{3, -1}, {6, 0}, {9, 0}}}};
@@ -66,11 +67,7 @@ namespace {
     // Degree  1     2     3  4     5     6     7
     // Degree  8     9    10 11    12    13    14
     // Index   0  1  2  3  4  5  6  7  8  9 10 11
-    const std::array<unsigned int, 14> degreeToPitchIndex = {0, 2, 4, 5, 7, 9, 11, 0, 2, 4, 5, 7, 9, 11};
-
-    // Some chromatic notes are adjusted by default, if they have not be otherwise adjusted by the algorithm.
-    // 99 is just a sentinel used for assertions.
-    const std::array<unsigned int, 12> defaultChromaticPitchMap = {99, 0, 99, 3, 99, 99, 7, 99, 7, 99, 10, 99};
+    const std::array<unsigned int, 15> degreeToPitchIndex = {999, 0, 2, 4, 5, 7, 9, 11, 0, 2, 4, 5, 7, 9, 11};
 
     using PitchIndexMap = std::array<unsigned int, 12>;
 
@@ -81,7 +78,14 @@ namespace {
         PitchIndexMap pitchIndexMap = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
 
         // Apply adjustments from the modifiers
-        const auto& adjustments = chordDegreeAdjustments.at(chordType);
+        const auto it = chordDegreeAdjustments.find(chordType);
+        assert(it != chordDegreeAdjustments.end() && "Chord type not found in adjustments map");
+        DegreeAdjustment adjustments = it->second;
+
+        // Apply defaults
+        adjustments[1] = 0; // Degree 0 (root) is always present.
+        adjustments.insert_or_assign(5, 0); // Degree 5 is assumed unless specified.
+
         for (const auto& [degree, adjustment] : adjustments) {
             assert(degree < degreeToPitchIndex.size() && "Degree out of range");
             const unsigned int sourcePitchIndex = degreeToPitchIndex[degree];
@@ -90,10 +94,7 @@ namespace {
             assert(targetPitchIndex < pitchIndexMap.size() && "Target pitch class out of range");
             pitchIndexMap[sourcePitchIndex] = targetPitchIndex;
             gravityMap[targetPitchIndex] = 1;
-            for (unsigned int index = sourcePitchIndex; index != targetPitchIndex; index += sgn(adjustment)) {
-                pitchIndexMap[sourcePitchIndex] = targetPitchIndex;
-                gravityMap[index] = -1;
-            }
+            gravityMap[sourcePitchIndex] = -1;
         }
         // For remaining chromatic notes, if either neighbouring note is a target of a modifier, pull it towards the
         // target.
@@ -108,12 +109,6 @@ namespace {
                     // This is left-biased, but I don't think it matters much.
                     pitchIndexMap[index] = (gravityMap[leftNeighbour] > gravityMap[rightNeighbour]) ? leftNeighbour
                                                                                                       : rightNeighbour;
-                }
-                else {
-                    // TODO Provide a policy so the user can opt out of this behaviour.
-                    // If neither neighbour is a target, use the default chromatic pitch map.
-                    pitchIndexMap[index] = defaultChromaticPitchMap[index];
-                    assert(pitchIndexMap[index] < 12 && "Default chromatic pitch index out of range");
                 }
             }
         }

--- a/MusicLib/Functions/fitToChordFunction.hpp
+++ b/MusicLib/Functions/fitToChordFunction.hpp
@@ -14,5 +14,10 @@
 
 namespace bw_music {
     /// Adjust a track of notes to fit a chord.
-    Track fitToChordFunction(const Track& sourceTrack, const Chord& chord);
+    Track fitToChordFunction(const Track& sourceTrack, const ChordType::Value& chordType);
+
+    // Produce a value the matches the input value, but adjusts any notes in any tracks to the given chord type.
+    babelwires::ValueHolder fitToChordFunction(const babelwires::TypeSystem& typeSystem, const babelwires::Type& type, const babelwires::ValueHolder& sourceValue,
+                                          const ChordType::Value& chordType);
+
 } // namespace bw_music

--- a/MusicLib/Functions/fitToChordFunction.hpp
+++ b/MusicLib/Functions/fitToChordFunction.hpp
@@ -1,0 +1,18 @@
+/**
+ * Function which adjusts a track of notes in C major to fit other chord types.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+
+#include <MusicLib/Types/Track/track.hpp>
+#include <MusicLib/chord.hpp>
+
+namespace bw_music {
+    /// Adjust a track of notes to fit a chord.
+    Track fitToChordFunction(const Track& sourceTrack, const Chord& chord);
+} // namespace bw_music

--- a/MusicLib/chord.hpp
+++ b/MusicLib/chord.hpp
@@ -50,7 +50,7 @@
     X(_1p8, "1+8", "63f443e4-93d5-4609-b91a-5a6491ac19be")                                                             \
     X(_1p5, "1+5", "a513bc99-e978-4699-bc7c-7e30d71f33d0")                                                             \
     X(sus4, "sus4", "ce218a4b-4600-47de-8a77-45a490457ff4")                                                            \
-    /* TODO: Is this the same as sus2 or is a separate chord type required ? */                                        \                                           
+    /* TODO: Is this the same as sus2 or is a separate chord type required ? */                                        \
     X(_1p2p5, "1+2+5", "28875d31-45c8-488f-9cc3-9172c0ad7929")                                                         \
     /* In the XF specification, "Cancel Chord" (CC) is in this position, but that's not an actual chord. */            \
     /* The following are not in the XF spec v2.01 but available on more recent keyboards. */                           \

--- a/MusicLib/chord.hpp
+++ b/MusicLib/chord.hpp
@@ -25,6 +25,7 @@
     X(aug, "aug", "430cf87e-5e5f-4075-b4fa-bee132085f8b")                                                              \
     X(m, "min", "59870eb3-9bb9-459e-8f81-601dd2c4d1f4")                                                                \
     X(m6, "min6", "1f1d80ea-f34a-4bc6-a3ec-0984088a502a")                                                              \
+    X(m6_9, "min6(9)", "1647d18d-db2a-4672-8e19-168ba1f53944")                                                          \
     X(m7, "min7", "d7d0154d-799f-4f96-afaf-23cda7de5b20")                                                              \
     X(m7b5, "min7b5", "7fa7e272-25f9-4cc7-afdd-0c4f2dfed16b")                                                          \
     X(m9, "min(9)", "7c12b85b-e490-420f-97de-dad20d31082c")                                                            \

--- a/MusicLib/chord.hpp
+++ b/MusicLib/chord.hpp
@@ -12,7 +12,9 @@
 #include <BabelWiresLib/Types/Enum/enumWithCppEnum.hpp>
 #include <BabelWiresLib/TypeSystem/primitiveType.hpp>
 
-/// These match the "Chord type" values from the XF Format Specifications v2.01
+/// Most chords below match the "Chord type" values from the XF Format Specifications v2.01
+/// Some additional chord types are not in the XF spec, but are needed for compatibility with
+/// other devices, such as the Roland PMA-5.
 // TODO Consider using \u266d (flat) and \u266f (sharp) in names.
 #define CHORD_TYPE_VALUES(X)                                                                                           \
     X(M, "Maj", "1ef34c5c-e8d4-4cac-b189-e4ac2fffefd4")                                                                \
@@ -48,14 +50,15 @@
     X(_1p8, "1+8", "63f443e4-93d5-4609-b91a-5a6491ac19be")                                                             \
     X(_1p5, "1+5", "a513bc99-e978-4699-bc7c-7e30d71f33d0")                                                             \
     X(sus4, "sus4", "ce218a4b-4600-47de-8a77-45a490457ff4")                                                            \
+    /* TODO: Is this the same as sus2 or is a separate chord type required ? */                                        \                                           
     X(_1p2p5, "1+2+5", "28875d31-45c8-488f-9cc3-9172c0ad7929")                                                         \
-    /* In the XF specification, "Cancel Chord" (CC) is in this position */                                             \
+    /* In the XF specification, "Cancel Chord" (CC) is in this position, but that's not an actual chord. */            \
     /* The following are not in the XF spec v2.01 but available on more recent keyboards. */                           \
     /* See the hpmidifile project for values */                                                                        \
     X(M7b5, "M7b5", "54f40058-ce9a-4c75-95c0-0ac7e66039aa")                                                            \
     X(b5, "b5", "9dba6ccc-946c-4fd8-a4a1-f5f8e27b74f1")                                                                \
     X(mM7b5, "mM7b5", "792e9dc3-c713-437f-a90e-d82e667cf2d0")                                                          \
-    /* Used in the Roland PMA-5 */                                                                                      \
+    /* See Roland PMA-5 manual, page 108 */                                                                            \
     X(m6_9, "min6(9)", "1647d18d-db2a-4672-8e19-168ba1f53944")
 
 #define CHORD_TYPE_SELECT_FIRST_ARGUMENT(A, B, C) A,

--- a/MusicLib/chord.hpp
+++ b/MusicLib/chord.hpp
@@ -25,7 +25,6 @@
     X(aug, "aug", "430cf87e-5e5f-4075-b4fa-bee132085f8b")                                                              \
     X(m, "min", "59870eb3-9bb9-459e-8f81-601dd2c4d1f4")                                                                \
     X(m6, "min6", "1f1d80ea-f34a-4bc6-a3ec-0984088a502a")                                                              \
-    X(m6_9, "min6(9)", "1647d18d-db2a-4672-8e19-168ba1f53944")                                                          \
     X(m7, "min7", "d7d0154d-799f-4f96-afaf-23cda7de5b20")                                                              \
     X(m7b5, "min7b5", "7fa7e272-25f9-4cc7-afdd-0c4f2dfed16b")                                                          \
     X(m9, "min(9)", "7c12b85b-e490-420f-97de-dad20d31082c")                                                            \
@@ -55,7 +54,9 @@
     /* See the hpmidifile project for values */                                                                        \
     X(M7b5, "M7b5", "54f40058-ce9a-4c75-95c0-0ac7e66039aa")                                                            \
     X(b5, "b5", "9dba6ccc-946c-4fd8-a4a1-f5f8e27b74f1")                                                                \
-    X(mM7b5, "mM7b5", "792e9dc3-c713-437f-a90e-d82e667cf2d0")
+    X(mM7b5, "mM7b5", "792e9dc3-c713-437f-a90e-d82e667cf2d0")                                                          \
+    /* Used in the Roland PMA-5 */                                                                                      \
+    X(m6_9, "min6(9)", "1647d18d-db2a-4672-8e19-168ba1f53944")
 
 #define CHORD_TYPE_SELECT_FIRST_ARGUMENT(A, B, C) A,
 


### PR DESCRIPTION
Provide a processor that adjusts track data (assumed to match a C Major chord) to fit other chords.

The main purpose of a chord track is to provide musical accompaniment. Accompaniment music is often written as short patterns of several tracks. The tracks _can_ be explicitly created to match each chord and that will definitely give the best result. However, accompaniment systems (e.g. found on arranger keyboards) often provide a short-cut: If the user provides an accompaniment to match C major and the system can automatically adjust the music to match other chords. 

As far as I can tell, there isn't a universally agreed way to do this, so I've attempted to provide my own version, based on an admittedly incomplete understanding of music theory.
