### PR TITLE
Rename PRIMITIVE_TYPE to REGISTERED_TYPE

### DIFF
--- a/MusicLib/Functions/fingeredChordsFunction.hpp
+++ b/MusicLib/Functions/fingeredChordsFunction.hpp
@@ -7,7 +7,7 @@
  **/
 #pragma once
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 #include <MusicLib/Types/Track/track.hpp>
 
@@ -22,7 +22,7 @@ namespace bw_music {
     /// a "Cancel Chord" event is observed (three consecutive pitches).
     class FingeredChordsSustainPolicyEnum : public babelwires::EnumType {
       public:
-        PRIMITIVE_TYPE("FingeredPolicy", "Fingered Chords Sustain Policy", "64bb3fa9-1b77-4629-b691-431713fe2eee", 1);
+        REGISTERED_TYPE("FingeredPolicy", "Fingered Chords Sustain Policy", "64bb3fa9-1b77-4629-b691-431713fe2eee", 1);
         FingeredChordsSustainPolicyEnum();
 
         ENUM_DEFINE_CPP_ENUM(FINGERED_CHORDS_SUSTAIN_POLICY);

--- a/MusicLib/Functions/monophonicSubtracksFunction.hpp
+++ b/MusicLib/Functions/monophonicSubtracksFunction.hpp
@@ -10,7 +10,7 @@
 #include <MusicLib/Types/Track/track.hpp>
 
 #include <BabelWiresLib/Types/Enum/enumWithCppEnum.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace bw_music {
 #define MONOPHONIC_SUBTRACK_POLICY(X)                                                                                  \
@@ -22,7 +22,7 @@ namespace bw_music {
     /// The enum that determines the algorithm used.
     class MonophonicSubtracksPolicyEnum : public babelwires::EnumType {
       public:
-        PRIMITIVE_TYPE("MonoPolicy", "Monophonic Subtracks Policy", "d9ae8da5-3001-45ff-b2ce-4375f7d18afd", 1);
+        REGISTERED_TYPE("MonoPolicy", "Monophonic Subtracks Policy", "d9ae8da5-3001-45ff-b2ce-4375f7d18afd", 1);
         MonophonicSubtracksPolicyEnum();
 
         ENUM_DEFINE_CPP_ENUM(MONOPHONIC_SUBTRACK_POLICY);

--- a/MusicLib/Functions/percussionMapFunction.cpp
+++ b/MusicLib/Functions/percussionMapFunction.cpp
@@ -28,7 +28,7 @@ bw_music::PercussionMapType::constructType(const babelwires::TypeSystem& typeSys
                                            const std::vector<babelwires::EditableValueHolder>& valueArguments) const {
 
     std::vector<babelwires::TypeRef> sourceSummands;
-    auto percussionTypes = typeSystem.getTaggedPrimitiveTypes(bw_music::percussionTypeTag());
+    auto percussionTypes = typeSystem.getTaggedRegisteredTypes(bw_music::percussionTypeTag());
     std::for_each(percussionTypes.begin(), percussionTypes.end(),
                   [&sourceSummands](babelwires::RegisteredTypeId typeId) { sourceSummands.emplace_back(typeId); });
 

--- a/MusicLib/Functions/percussionMapFunction.cpp
+++ b/MusicLib/Functions/percussionMapFunction.cpp
@@ -30,7 +30,7 @@ bw_music::PercussionMapType::constructType(const babelwires::TypeSystem& typeSys
     std::vector<babelwires::TypeRef> sourceSummands;
     auto percussionTypes = typeSystem.getTaggedPrimitiveTypes(bw_music::percussionTypeTag());
     std::for_each(percussionTypes.begin(), percussionTypes.end(),
-                  [&sourceSummands](babelwires::PrimitiveTypeId typeId) { sourceSummands.emplace_back(typeId); });
+                  [&sourceSummands](babelwires::RegisteredTypeId typeId) { sourceSummands.emplace_back(typeId); });
 
     const auto it =
         std::find(sourceSummands.begin(), sourceSummands.end(), bw_music::BuiltInPercussionInstruments::getThisType());

--- a/MusicLib/Percussion/builtInPercussionInstruments.hpp
+++ b/MusicLib/Percussion/builtInPercussionInstruments.hpp
@@ -10,7 +10,7 @@
 #include <MusicLib/musicTypes.hpp>
 
 #include <BabelWiresLib/Types/Enum/enumWithCppEnum.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 #include <optional>
 
@@ -229,7 +229,7 @@ namespace bw_music {
     /// mapping to pitch values.
     class BuiltInPercussionInstruments : public babelwires::EnumType {
       public:
-        PRIMITIVE_TYPE("BuiltInPerc", "Built In Percussion", "c67f1a9e-653d-42b5-bf73-1fdc2f8a9b1a", 1);
+        REGISTERED_TYPE("BuiltInPerc", "Built In Percussion", "c67f1a9e-653d-42b5-bf73-1fdc2f8a9b1a", 1);
 
         BuiltInPercussionInstruments();
 

--- a/MusicLib/Percussion/percussionTypeTag.hpp
+++ b/MusicLib/Percussion/percussionTypeTag.hpp
@@ -7,7 +7,7 @@
  **/
 #pragma once
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Enum/enumType.hpp>
 
 namespace bw_music {

--- a/MusicLib/Processors/chordMapProcessor.hpp
+++ b/MusicLib/Processors/chordMapProcessor.hpp
@@ -18,7 +18,7 @@ namespace bw_music {
 
     class ChordMapProcessorInput : public babelwires::ParallelProcessorInputBase {
       public:
-        PRIMITIVE_TYPE("ChordMapIn", "ChordMap In", "9a6aac86-fc46-40e2-91ba-c0fb053ad172", 1);
+        REGISTERED_TYPE("ChordMapIn", "ChordMap In", "9a6aac86-fc46-40e2-91ba-c0fb053ad172", 1);
 
         ChordMapProcessorInput();
 
@@ -29,7 +29,7 @@ namespace bw_music {
 
     class ChordMapProcessorOutput : public babelwires::ParallelProcessorOutputBase {
       public:
-        PRIMITIVE_TYPE("ChordMapOut", "ChordMap Out", "e7ed549d-d6ef-4cca-b66e-5b271d00e0b2", 1);
+        REGISTERED_TYPE("ChordMapOut", "ChordMap Out", "e7ed549d-d6ef-4cca-b66e-5b271d00e0b2", 1);
 
         ChordMapProcessorOutput();
     };

--- a/MusicLib/Processors/concatenateProcessor.hpp
+++ b/MusicLib/Processors/concatenateProcessor.hpp
@@ -13,7 +13,7 @@
 #include <BabelWiresLib/Instance/instance.hpp>
 #include <BabelWiresLib/Processors/processorFactory.hpp>
 #include <BabelWiresLib/Processors/processor.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
 
@@ -21,7 +21,7 @@ namespace bw_music {
 
     class ConcatenateProcessorInput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("ConcatTrcksIn", "Concatenate In", "f4f21fe1-25e6-4721-a298-36fe27b532cc", 1);
+        REGISTERED_TYPE("ConcatTrcksIn", "Concatenate In", "f4f21fe1-25e6-4721-a298-36fe27b532cc", 1);
 
         ConcatenateProcessorInput();
 
@@ -32,7 +32,7 @@ namespace bw_music {
 
     class ConcatenateProcessorOutput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("ConcatTrcksOut", "Concatenate Out", "2c9e13aa-eb88-494f-b3a6-7fb82504196c", 1);
+        REGISTERED_TYPE("ConcatTrcksOut", "Concatenate Out", "2c9e13aa-eb88-494f-b3a6-7fb82504196c", 1);
 
         ConcatenateProcessorOutput();
 

--- a/MusicLib/Processors/excerptProcessor.hpp
+++ b/MusicLib/Processors/excerptProcessor.hpp
@@ -15,7 +15,7 @@ namespace bw_music {
 
     class ExcerptProcessorInput : public babelwires::ParallelProcessorInputBase {
       public:
-        PRIMITIVE_TYPE("ExcerptTrckIn", "Excerpt In", "68577705-b5c2-499c-a2db-8ab5f63e5728", 1);
+        REGISTERED_TYPE("ExcerptTrckIn", "Excerpt In", "68577705-b5c2-499c-a2db-8ab5f63e5728", 1);
 
         ExcerptProcessorInput();
 
@@ -28,7 +28,7 @@ namespace bw_music {
 
     class ExcerptProcessorOutput : public babelwires::ParallelProcessorOutputBase {
       public:
-        PRIMITIVE_TYPE("ExcerptTrckOut", "Excerpt Out", "73469491-111c-441a-b89c-2f8aceaa640c", 1);
+        REGISTERED_TYPE("ExcerptTrckOut", "Excerpt Out", "73469491-111c-441a-b89c-2f8aceaa640c", 1);
 
         ExcerptProcessorOutput();
     };

--- a/MusicLib/Processors/fingeredChordsProcessor.hpp
+++ b/MusicLib/Processors/fingeredChordsProcessor.hpp
@@ -12,13 +12,13 @@
 #include <BabelWiresLib/Instance/instance.hpp>
 #include <BabelWiresLib/Processors/processorFactory.hpp>
 #include <BabelWiresLib/Processors/processor.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
 namespace bw_music {
     class FingeredChordsProcessorInput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("FingrChordsIn", "Fingered Chords Input", "c9f26551-f557-4b27-ba0c-385298a2e51e", 1);
+        REGISTERED_TYPE("FingrChordsIn", "Fingered Chords Input", "c9f26551-f557-4b27-ba0c-385298a2e51e", 1);
 
         FingeredChordsProcessorInput();
 
@@ -30,7 +30,7 @@ namespace bw_music {
 
     class FingeredChordsProcessorOutput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("FingrChordsOut", "Fingered Chords Output", "f53cb215-1f8e-491b-8baf-868a5a5d0173", 1);
+        REGISTERED_TYPE("FingrChordsOut", "Fingered Chords Output", "f53cb215-1f8e-491b-8baf-868a5a5d0173", 1);
 
         FingeredChordsProcessorOutput();
 

--- a/MusicLib/Processors/mergeProcessor.hpp
+++ b/MusicLib/Processors/mergeProcessor.hpp
@@ -13,13 +13,13 @@
 #include <BabelWiresLib/Instance/instance.hpp>
 #include <BabelWiresLib/Processors/processorFactory.hpp>
 #include <BabelWiresLib/Processors/processor.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
 namespace bw_music {
     class MergeProcessorInput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("MergeTracksIn", "Merge Tracks Input", "15dd4564-e67f-4087-8609-ef5985b23dd7", 1);
+        REGISTERED_TYPE("MergeTracksIn", "Merge Tracks Input", "15dd4564-e67f-4087-8609-ef5985b23dd7", 1);
 
         MergeProcessorInput();
 
@@ -30,7 +30,7 @@ namespace bw_music {
 
     class MergeProcessorOutput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("MergeTracksOut", "Merge Tracks Output", "9b797596-f6c2-4900-98a4-001ec7c18be4", 1);
+        REGISTERED_TYPE("MergeTracksOut", "Merge Tracks Output", "9b797596-f6c2-4900-98a4-001ec7c18be4", 1);
 
         MergeProcessorOutput();
 

--- a/MusicLib/Processors/monophonicSubtracksProcessor.hpp
+++ b/MusicLib/Processors/monophonicSubtracksProcessor.hpp
@@ -14,13 +14,13 @@
 #include <BabelWiresLib/Instance/instance.hpp>
 #include <BabelWiresLib/Processors/processorFactory.hpp>
 #include <BabelWiresLib/Processors/processor.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
 namespace bw_music {
     class MonophonicSubtracksProcessorInput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("MonoTracksIn", "Monophonic Tracks Input", "e8041fe6-29de-470e-9235-e1f05c5f791e", 1);
+        REGISTERED_TYPE("MonoTracksIn", "Monophonic Tracks Input", "e8041fe6-29de-470e-9235-e1f05c5f791e", 1);
 
         MonophonicSubtracksProcessorInput();
 
@@ -33,7 +33,7 @@ namespace bw_music {
 
     class MonophonicSubtracksProcessorOutput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("MonoTracksOut", "Monophonic Tracks Output", "c2228921-da8a-45c0-bebf-24951d651090", 1);
+        REGISTERED_TYPE("MonoTracksOut", "Monophonic Tracks Output", "c2228921-da8a-45c0-bebf-24951d651090", 1);
 
         MonophonicSubtracksProcessorOutput();
 

--- a/MusicLib/Processors/percussionMapProcessor.hpp
+++ b/MusicLib/Processors/percussionMapProcessor.hpp
@@ -18,7 +18,7 @@ namespace bw_music {
 
     class PercussionMapProcessorInput : public babelwires::ParallelProcessorInputBase {
       public:
-        PRIMITIVE_TYPE("PercMapIn", "PercussionMap In", "d422110c-3ea4-42a3-86b0-311332836504", 1);
+        REGISTERED_TYPE("PercMapIn", "PercussionMap In", "d422110c-3ea4-42a3-86b0-311332836504", 1);
 
         PercussionMapProcessorInput();
 
@@ -29,7 +29,7 @@ namespace bw_music {
 
     class PercussionMapProcessorOutput : public babelwires::ParallelProcessorOutputBase {
       public:
-        PRIMITIVE_TYPE("PercMapOut", "PercussionMap Out", "e0940d22-c79a-4139-a0ef-00aee485ef2a", 1);
+        REGISTERED_TYPE("PercMapOut", "PercussionMap Out", "e0940d22-c79a-4139-a0ef-00aee485ef2a", 1);
 
         PercussionMapProcessorOutput();
     };

--- a/MusicLib/Processors/quantizeProcessor.hpp
+++ b/MusicLib/Processors/quantizeProcessor.hpp
@@ -18,7 +18,7 @@ namespace bw_music {
 
     class QuantizeProcessorInput : public babelwires::ParallelProcessorInputBase {
       public:
-        PRIMITIVE_TYPE("QuantTrcksIn", "Quantize In", "86a46b16-69a3-41bb-bbb3-19f8cb0a4e4d", 1);
+        REGISTERED_TYPE("QuantTrcksIn", "Quantize In", "86a46b16-69a3-41bb-bbb3-19f8cb0a4e4d", 1);
 
         QuantizeProcessorInput();
 
@@ -30,7 +30,7 @@ namespace bw_music {
 
     class QuantizeProcessorOutput : public babelwires::ParallelProcessorOutputBase {
       public:
-        PRIMITIVE_TYPE("QuantTrcksOut", "Quantize Out", "89feb462-63b1-473a-bc77-29540bda43f7", 1);
+        REGISTERED_TYPE("QuantTrcksOut", "Quantize Out", "89feb462-63b1-473a-bc77-29540bda43f7", 1);
 
         QuantizeProcessorOutput();
     };

--- a/MusicLib/Processors/repeatProcessor.hpp
+++ b/MusicLib/Processors/repeatProcessor.hpp
@@ -14,7 +14,7 @@
 namespace bw_music {
     class RepeatProcessorInput : public babelwires::ParallelProcessorInputBase {
       public:
-        PRIMITIVE_TYPE("RepeatTrcksIn", "Repeat In", "23dc427d-8171-4de4-a9b6-15c16d9ed373", 1);
+        REGISTERED_TYPE("RepeatTrcksIn", "Repeat In", "23dc427d-8171-4de4-a9b6-15c16d9ed373", 1);
 
         RepeatProcessorInput();
 
@@ -26,7 +26,7 @@ namespace bw_music {
 
     class RepeatProcessorOutput : public babelwires::ParallelProcessorOutputBase {
       public:
-        PRIMITIVE_TYPE("RepeatTrcksOut", "Repeat Out", "c0d3c991-8e57-4bb9-86bd-68fdbf854434", 1);
+        REGISTERED_TYPE("RepeatTrcksOut", "Repeat Out", "c0d3c991-8e57-4bb9-86bd-68fdbf854434", 1);
 
         RepeatProcessorOutput();
     };

--- a/MusicLib/Processors/silenceProcessor.hpp
+++ b/MusicLib/Processors/silenceProcessor.hpp
@@ -13,13 +13,13 @@
 #include <BabelWiresLib/Instance/instance.hpp>
 #include <BabelWiresLib/Processors/processorFactory.hpp>
 #include <BabelWiresLib/Processors/processor.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
 namespace bw_music {
     class SilenceProcessorInput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("SilentTrackIn", "Silence In", "b3d5c37c-aa07-47ac-9ebb-3cf81731b97b", 1);
+        REGISTERED_TYPE("SilentTrackIn", "Silence In", "b3d5c37c-aa07-47ac-9ebb-3cf81731b97b", 1);
 
         SilenceProcessorInput();
 
@@ -30,7 +30,7 @@ namespace bw_music {
 
     class SilenceProcessorOutput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("SilentTrackOut", "Silence Out", "fd8b4645-1435-448c-bf9d-0cebf8999a81", 1);
+        REGISTERED_TYPE("SilentTrackOut", "Silence Out", "fd8b4645-1435-448c-bf9d-0cebf8999a81", 1);
 
         SilenceProcessorOutput();
 

--- a/MusicLib/Processors/splitAtPitchProcessor.cpp
+++ b/MusicLib/Processors/splitAtPitchProcessor.cpp
@@ -42,7 +42,6 @@ void bw_music::SplitAtPitchProcessor::processValue(babelwires::UserLogger& userL
         const int pitchIndex = pitch.getInstanceType().tryGetIndexFromIdentifier(pitch.get().get());
         if (pitchIndex >= 0) {
             auto newTracksOut = splitAtPitch(Pitch(pitchIndex), trackIn.get());
-            auto outputType = output.getTypeRef().toString();
             SplitAtPitchProcessorOutput::Instance out{output};
             out.getAbove().set(std::move(newTracksOut.m_equalOrAbove));
             out.getBelow().set(std::move(newTracksOut.m_below));

--- a/MusicLib/Processors/splitAtPitchProcessor.hpp
+++ b/MusicLib/Processors/splitAtPitchProcessor.hpp
@@ -14,13 +14,13 @@
 #include <BabelWiresLib/Instance/instance.hpp>
 #include <BabelWiresLib/Processors/processorFactory.hpp>
 #include <BabelWiresLib/Processors/processor.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
 namespace bw_music {
     class SplitAtPitchProcessorInput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("PitchSplitIn", "Split At Pitch Input", "f901af3a-c27b-449c-961a-8f43dee7d9a6", 1);
+        REGISTERED_TYPE("PitchSplitIn", "Split At Pitch Input", "f901af3a-c27b-449c-961a-8f43dee7d9a6", 1);
 
         SplitAtPitchProcessorInput();
 
@@ -32,7 +32,7 @@ namespace bw_music {
 
     class SplitAtPitchProcessorOutput : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("PitchSplitOut", "Split At Pitch Output", "50f790e1-0ef3-4f34-ad14-5a6762772e19", 1);
+        REGISTERED_TYPE("PitchSplitOut", "Split At Pitch Output", "50f790e1-0ef3-4f34-ad14-5a6762772e19", 1);
 
         SplitAtPitchProcessorOutput();
 

--- a/MusicLib/Processors/transposeProcessor.hpp
+++ b/MusicLib/Processors/transposeProcessor.hpp
@@ -15,7 +15,7 @@ namespace bw_music {
 
     class TransposeProcessorInput : public babelwires::ParallelProcessorInputBase {
       public:
-        PRIMITIVE_TYPE("TranspTrcksIn", "Transpose In", "980af793-e5fe-4fa4-861c-90f400fc4977", 1);
+        REGISTERED_TYPE("TranspTrcksIn", "Transpose In", "980af793-e5fe-4fa4-861c-90f400fc4977", 1);
 
         TransposeProcessorInput();
 
@@ -26,7 +26,7 @@ namespace bw_music {
 
     class TransposeProcessorOutput : public babelwires::ParallelProcessorOutputBase {
       public:
-        PRIMITIVE_TYPE("TranspTrcksOut", "Transpose Out", "e2c9d64e-259a-4ef5-bd9d-0883c5d67599", 1);
+        REGISTERED_TYPE("TranspTrcksOut", "Transpose Out", "e2c9d64e-259a-4ef5-bd9d-0883c5d67599", 1);
 
         TransposeProcessorOutput();
     };

--- a/MusicLib/Types/Track/trackType.hpp
+++ b/MusicLib/Types/Track/trackType.hpp
@@ -34,6 +34,6 @@ namespace bw_music {
     /// The standard TrackType which creates empty Tracks with 0 duration.
     class DefaultTrackType : public TrackType {
       public:
-        PRIMITIVE_TYPE("track", "Track", "346ec14c-25dd-43fc-a942-d24722be6802", 1);
+        REGISTERED_TYPE("track", "Track", "346ec14c-25dd-43fc-a942-d24722be6802", 1);
     };
 } // namespace bw_music

--- a/MusicLib/Types/duration.hpp
+++ b/MusicLib/Types/duration.hpp
@@ -14,7 +14,7 @@ namespace bw_music {
     /// Duration is a RationalType for holding a duration.
     class Duration : public babelwires::RationalType {
       public:
-        PRIMITIVE_TYPE("duration", "Duration", "d88c867e-f395-4f3c-bbe6-81c46314f3e5", 1);
+        REGISTERED_TYPE("duration", "Duration", "d88c867e-f395-4f3c-bbe6-81c46314f3e5", 1);
         Duration() : babelwires::RationalType({0, std::numeric_limits<babelwires::Rational::ComponentType>::max()}, 0) {}
     };
 

--- a/MusicLib/Types/tempo.hpp
+++ b/MusicLib/Types/tempo.hpp
@@ -16,7 +16,7 @@ namespace bw_music {
     /// The default tempo is 120.
     class Tempo : public babelwires::IntType {
       public:
-        PRIMITIVE_TYPE("tempo", "Tempo", "6ee26c7f-ced6-400d-a927-9464a143b39c", 1);
+        REGISTERED_TYPE("tempo", "Tempo", "6ee26c7f-ced6-400d-a927-9464a143b39c", 1);
         Tempo() : babelwires::IntType({0, 255}, 120) {}
     };
 

--- a/MusicLib/chord.hpp
+++ b/MusicLib/chord.hpp
@@ -10,7 +10,7 @@
 #include <MusicLib/musicTypes.hpp>
 
 #include <BabelWiresLib/Types/Enum/enumWithCppEnum.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 /// These match the "Chord type" values from the XF Format Specifications v2.01
 // TODO Consider using \u266d (flat) and \u266f (sharp) in names.
@@ -67,7 +67,7 @@ namespace bw_music {
     /// Carries the enum of chord types.
     class ChordType : public babelwires::EnumType {
       public:
-        PRIMITIVE_TYPE("ChordType", "Chord Type", "c63ea174-1562-4cb5-a456-d6c0bd89e335", 1);
+        REGISTERED_TYPE("ChordType", "Chord Type", "c63ea174-1562-4cb5-a456-d6c0bd89e335", 1);
 
         ChordType();
 
@@ -88,7 +88,7 @@ namespace bw_music {
     /// A type with a single value meaning "NoChord".
     class NoChord : public babelwires::EnumType {
       public:
-        PRIMITIVE_TYPE("NoChord", "No Chord", "5f51a358-0121-4d1d-a0ab-cce5bddf92f1", 1);
+        REGISTERED_TYPE("NoChord", "No Chord", "5f51a358-0121-4d1d-a0ab-cce5bddf92f1", 1);
 
         NoChord();
 

--- a/MusicLib/pitch.hpp
+++ b/MusicLib/pitch.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <BabelWiresLib/Types/Enum/enumWithCppEnum.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 #include <Common/Math/rational.hpp>
 #include <Common/types.hpp>
@@ -40,7 +40,7 @@ namespace bw_music {
     /// An Enum corresponding to the twelve pitch classes of the western scale.
     class PitchClass : public babelwires::EnumType {
       public:
-        PRIMITIVE_TYPE("PitchClass", "Pitch Class", "0c7fed24-9923-42d3-9ad1-5879bf1c8af6", 1);
+        REGISTERED_TYPE("PitchClass", "Pitch Class", "0c7fed24-9923-42d3-9ad1-5879bf1c8af6", 1);
         PitchClass();
 
         ENUM_DEFINE_CPP_ENUM(PITCH_CLASS_VALUES);
@@ -62,7 +62,7 @@ namespace bw_music {
     // TODO: The UI dropdown presents this in a counter-intuitive order.
     class PitchEnum : public babelwires::EnumType {
       public:
-        PRIMITIVE_TYPE("Pitch", "Pitch", "c3acb960-b472-488b-a6da-8672b584dfb1", 1);
+        REGISTERED_TYPE("Pitch", "Pitch", "c3acb960-b472-488b-a6da-8672b584dfb1", 1);
         PitchEnum();
     };
 

--- a/Plugins/Smf/Plugin/Percussion/gm2AnalogPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gm2AnalogPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GM2 Analog Percussion Set.
     class GM2AnalogPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GM2AnalogPerc", "General MIDI 2 Analog Percussion", "a077c9c6-e66d-46d2-b5e2-0e839b99ae70", 1);
+        REGISTERED_TYPE("GM2AnalogPerc", "General MIDI 2 Analog Percussion", "a077c9c6-e66d-46d2-b5e2-0e839b99ae70", 1);
         GM2AnalogPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };
 } // namespace smf

--- a/Plugins/Smf/Plugin/Percussion/gm2BrushPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gm2BrushPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GM2 Brush Percussion Set.
     class GM2BrushPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GM2BrushPerc", "General MIDI 2 Brush Percussion", "9686b521-ffb2-4275-b98a-e7e6cdc1f91d", 1);
+        REGISTERED_TYPE("GM2BrushPerc", "General MIDI 2 Brush Percussion", "9686b521-ffb2-4275-b98a-e7e6cdc1f91d", 1);
         GM2BrushPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };
 } // namespace smf

--- a/Plugins/Smf/Plugin/Percussion/gm2ElectronicPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gm2ElectronicPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GM2 Electronic Percussion Set.
     class GM2ElectronicPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GM2ElecPerc", "General MIDI 2 Electronic Percussion", "cd9a66f3-baa8-49f0-844b-c41642e945d5", 1);
+        REGISTERED_TYPE("GM2ElecPerc", "General MIDI 2 Electronic Percussion", "cd9a66f3-baa8-49f0-844b-c41642e945d5", 1);
         GM2ElectronicPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };
 } // namespace smf

--- a/Plugins/Smf/Plugin/Percussion/gm2JazzPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gm2JazzPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GM2 Jazz percussion set.
     class GM2JazzPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GM2JazzPerc", "General MIDI 2 Jazz Percussion", "19ff2ea7-10e7-47d1-866d-ae241be9f3cc", 1);
+        REGISTERED_TYPE("GM2JazzPerc", "General MIDI 2 Jazz Percussion", "19ff2ea7-10e7-47d1-866d-ae241be9f3cc", 1);
         GM2JazzPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };
 } // namespace smf

--- a/Plugins/Smf/Plugin/Percussion/gm2OrchestraPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gm2OrchestraPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GM2 Orchestra percussion set.
     class GM2OrchestraPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GM2OrchPerc", "General MIDI 2 Orchestra Percussion", "6a77f085-35c7-409c-92e1-5f4a20f3c750", 1);
+        REGISTERED_TYPE("GM2OrchPerc", "General MIDI 2 Orchestra Percussion", "6a77f085-35c7-409c-92e1-5f4a20f3c750", 1);
 
         GM2OrchestraPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gm2PowerPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gm2PowerPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GM2 Power Percussion set.
     class GM2PowerPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GM2PowerPerc", "General MIDI 2 Power Percussion", "5405b858-e0e7-4aae-877a-557c1cb00826", 1);
+        REGISTERED_TYPE("GM2PowerPerc", "General MIDI 2 Power Percussion", "5405b858-e0e7-4aae-877a-557c1cb00826", 1);
 
         GM2PowerPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gm2RoomPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gm2RoomPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GM2 Standard Percussion Set.
     class GM2RoomPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GM2RoomPerc", "General MIDI 2 Room Percussion", "2192afce-6dea-4ca0-a5d9-551f9e852e5e", 1);
+        REGISTERED_TYPE("GM2RoomPerc", "General MIDI 2 Room Percussion", "2192afce-6dea-4ca0-a5d9-551f9e852e5e", 1);
 
         GM2RoomPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gm2SFXPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gm2SFXPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GM2 SFX percussion set.
     class GM2SFXPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GM2SFXPerc", "General MIDI 2 SFX Percussion", "5d51ad28-2f32-467e-a5be-8caafe3e6b39", 1);
+        REGISTERED_TYPE("GM2SFXPerc", "General MIDI 2 SFX Percussion", "5d51ad28-2f32-467e-a5be-8caafe3e6b39", 1);
 
         GM2SFXPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gm2StandardPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gm2StandardPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GM2 standard percussion set.
     class GM2StandardPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GM2StandPerc", "General MIDI 2 Standard Percussion", "9fc0c107-f76c-432a-af58-c794f01df455", 1);
+        REGISTERED_TYPE("GM2StandPerc", "General MIDI 2 Standard Percussion", "9fc0c107-f76c-432a-af58-c794f01df455", 1);
 
         GM2StandardPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gmPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gmPercussionSet.hpp
@@ -9,7 +9,7 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     // TODO GS, XG percussion, with appropriate subtyping.
@@ -17,7 +17,7 @@ namespace smf {
     /// A PercussionSet corresponding to the original General MIDI percussion set.
     class GMPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GMPerc", "General MIDI Percussion", "7571c9ca-1c7f-4547-9218-391a339bae7d", 1);
+        REGISTERED_TYPE("GMPerc", "General MIDI Percussion", "7571c9ca-1c7f-4547-9218-391a339bae7d", 1);
 
         GMPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gs808909PercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gs808909PercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GS 808/909 percussion set.
     class Gs808909PercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GS808909Perc", "Roland GS 808/909 Percussion", "fc25e9e7-0462-4581-adb6-924e3aee22be", 1);
+        REGISTERED_TYPE("GS808909Perc", "Roland GS 808/909 Percussion", "fc25e9e7-0462-4581-adb6-924e3aee22be", 1);
 
         Gs808909PercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gsBrushPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gsBrushPercussionSet.hpp
@@ -9,14 +9,14 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GS standard percussion set.
     /// There are two such sets, but we do not distinguish them
     class GsBrushPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GSBrushPerc", "Roland GS Brush Percussion", "8a2d5bde-833f-43ea-9c6c-86c22174688b", 1);
+        REGISTERED_TYPE("GSBrushPerc", "Roland GS Brush Percussion", "8a2d5bde-833f-43ea-9c6c-86c22174688b", 1);
 
         GsBrushPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gsElectronicPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gsElectronicPercussionSet.hpp
@@ -9,14 +9,14 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GS Electronic Percussion Set.
     /// This can also serve for the GS Dance set.
     class GsElectronicPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GSElecPerc", "Roland GS Electronic Percussion", "9ed6fdd8-f4d3-4944-b24f-a34d85d67fdb",
+        REGISTERED_TYPE("GSElecPerc", "Roland GS Electronic Percussion", "9ed6fdd8-f4d3-4944-b24f-a34d85d67fdb",
                        1);
 
         GsElectronicPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);

--- a/Plugins/Smf/Plugin/Percussion/gsJazzPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gsJazzPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GS Jazz Percussion set.
     class GsJazzPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GSJazzPerc", "Roland GS Jazz Percussion", "82bf0d75-260c-46f3-91d0-1d09b5494022", 1);
+        REGISTERED_TYPE("GSJazzPerc", "Roland GS Jazz Percussion", "82bf0d75-260c-46f3-91d0-1d09b5494022", 1);
 
         GsJazzPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gsOrchestraPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gsOrchestraPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GS Orchestra percussion set.
     class GsOrchestraPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GSOrchPerc", "Roland GS Orchestra Percussion", "31152c6f-c782-4c02-9125-d2cbcc49ca7e", 1);
+        REGISTERED_TYPE("GSOrchPerc", "Roland GS Orchestra Percussion", "31152c6f-c782-4c02-9125-d2cbcc49ca7e", 1);
 
         GsOrchestraPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gsPowerPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gsPowerPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GS Power percussion set.
     class GsPowerPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GSPowerPerc", "Roland GS Power Percussion", "75470199-d7ee-4648-b922-ca8a62b21f02", 1);
+        REGISTERED_TYPE("GSPowerPerc", "Roland GS Power Percussion", "75470199-d7ee-4648-b922-ca8a62b21f02", 1);
 
         GsPowerPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gsRoomPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gsRoomPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GS standard percussion set.
     class GsRoomPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GSRoomPerc", "Roland GS Room Percussion", "ea4fe75f-71ff-42c7-9480-99486b513d37", 1);
+        REGISTERED_TYPE("GSRoomPerc", "Roland GS Room Percussion", "ea4fe75f-71ff-42c7-9480-99486b513d37", 1);
         GsRoomPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };
 } // namespace smf

--- a/Plugins/Smf/Plugin/Percussion/gsSFXPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gsSFXPercussionSet.hpp
@@ -9,14 +9,14 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GS standard percussion set.
     /// There are two such sets, but we do not distinguish them
     class GsSFXPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GSSFXPerc", "Roland GS SFX Percussion", "135823fa-ec1b-427e-9e03-f888be7383c8", 1);
+        REGISTERED_TYPE("GSSFXPerc", "Roland GS SFX Percussion", "135823fa-ec1b-427e-9e03-f888be7383c8", 1);
 
         GsSFXPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/gsStandard1PercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/gsStandard1PercussionSet.hpp
@@ -9,14 +9,14 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of GS standard percussion set.
     /// There are two such sets, but we do not distinguish them
     class GsStandard1PercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("GSStand1Perc", "Roland GS Standard 1 Percussion", "a1fb9fe9-98d0-4f56-ab75-49b9c936d246", 1);
+        REGISTERED_TYPE("GSStand1Perc", "Roland GS Standard 1 Percussion", "a1fb9fe9-98d0-4f56-ab75-49b9c936d246", 1);
 
         GsStandard1PercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/xgAnalogPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/xgAnalogPercussionSet.hpp
@@ -9,14 +9,14 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of XG Analog percussion set.
     /// This also works as the XG Standard 2 percussion set.
     class XgAnalogPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("XGAnalogPerc", "Yamaha XG Analog Percussion", "f172fe57-7ec0-43de-9031-3a4ebe3da84d", 1);
+        REGISTERED_TYPE("XGAnalogPerc", "Yamaha XG Analog Percussion", "f172fe57-7ec0-43de-9031-3a4ebe3da84d", 1);
 
         XgAnalogPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/xgBrushPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/xgBrushPercussionSet.hpp
@@ -9,14 +9,14 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of XG Standard 1 percussion set.
     /// This also works as the XG Standard 2 percussion set.
     class XgBrushPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("XGBrushPerc", "Yamaha XG BrushPercussion", "096bbcd8-5302-42e0-9ac9-560fd7a570f3", 1);
+        REGISTERED_TYPE("XGBrushPerc", "Yamaha XG BrushPercussion", "096bbcd8-5302-42e0-9ac9-560fd7a570f3", 1);
 
         XgBrushPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/xgClassicPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/xgClassicPercussionSet.hpp
@@ -9,14 +9,14 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of XG Standard 1 percussion set.
     /// This also works as the XG Standard 2 percussion set.
     class XgClassicPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("XGClassicPerc", "Yamaha XG Classic Percussion", "f7c61e91-dee8-4244-83a6-8aa0c1506964", 1);
+        REGISTERED_TYPE("XGClassicPerc", "Yamaha XG Classic Percussion", "f7c61e91-dee8-4244-83a6-8aa0c1506964", 1);
 
         XgClassicPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/xgElectroPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/xgElectroPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of XG Electro percussion set.
     class XgElectroPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("XGElectroPerc", "Yamaha XG Electro Percussion", "eb1c03a3-292c-4bc9-b932-ce1c989e02ca", 1);
+        REGISTERED_TYPE("XGElectroPerc", "Yamaha XG Electro Percussion", "eb1c03a3-292c-4bc9-b932-ce1c989e02ca", 1);
 
         XgElectroPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/xgJazzPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/xgJazzPercussionSet.hpp
@@ -9,14 +9,14 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of XG Jazz percussion set.
     /// This also works as the XG Standard 2 percussion set.
     class XgJazzPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("XGJazzPerc", "Yamaha XG Jazz Percussion", "101d8344-28c4-4045-83aa-52dc87fe5235", 1);
+        REGISTERED_TYPE("XGJazzPerc", "Yamaha XG Jazz Percussion", "101d8344-28c4-4045-83aa-52dc87fe5235", 1);
 
         XgJazzPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/xgRockPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/xgRockPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of XG Rock percussion set.
     class XgRockPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("XGRockPerc", "Yamaha XG Rock Percussion", "f398844b-8624-4896-bbb9-23ad250fb83b", 1);
+        REGISTERED_TYPE("XGRockPerc", "Yamaha XG Rock Percussion", "f398844b-8624-4896-bbb9-23ad250fb83b", 1);
 
         XgRockPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/xgRoomPercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/xgRoomPercussionSet.hpp
@@ -9,13 +9,13 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of XG Room percussion set.
     class XgRoomPercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("XGRoomPerc", "Yamaha XG Room Percussion", "4ad1aa44-6e23-4f3e-ae83-75b0b1edad4a", 1);
+        REGISTERED_TYPE("XGRoomPerc", "Yamaha XG Room Percussion", "4ad1aa44-6e23-4f3e-ae83-75b0b1edad4a", 1);
 
         XgRoomPercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/xgSFX1PercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/xgSFX1PercussionSet.hpp
@@ -9,14 +9,14 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of XG SFX 1 percussion set.
     /// This also works as the XG Standard 2 percussion set.
     class XgSFX1PercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("XGSFX1Perc", "Yamaha XG SFX 1 Percussion", "fb2f88a2-de91-418d-8b8c-26aaac97c1ba", 1);
+        REGISTERED_TYPE("XGSFX1Perc", "Yamaha XG SFX 1 Percussion", "fb2f88a2-de91-418d-8b8c-26aaac97c1ba", 1);
 
         XgSFX1PercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/xgSFX2PercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/xgSFX2PercussionSet.hpp
@@ -9,14 +9,14 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of XG SFX 1 percussion set.
     /// This also works as the XG Standard 2 percussion set.
     class XgSFX2PercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("XGSFX2Perc", "Yamaha XG SFX 2 Percussion", "217785d3-ac7b-4a2f-9e7b-21e601cf0485", 1);
+        REGISTERED_TYPE("XGSFX2Perc", "Yamaha XG SFX 2 Percussion", "217785d3-ac7b-4a2f-9e7b-21e601cf0485", 1);
 
         XgSFX2PercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/Percussion/xgStandard1PercussionSet.hpp
+++ b/Plugins/Smf/Plugin/Percussion/xgStandard1PercussionSet.hpp
@@ -9,14 +9,14 @@
 
 #include <MusicLib/Percussion/percussionSetWithPitchMap.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace smf {
     /// A PercussionSet corresponding to the instruments of XG Standard 1 percussion set.
     /// This also works as the XG Standard 2 percussion set.
     class XgStandard1PercussionSet : public bw_music::PercussionSetWithPitchMap {
       public:
-        PRIMITIVE_TYPE("XGStand1Perc", "Yamaha XG Standard 1 Percussion", "4c094420-0a8e-4dfa-b315-2bdb516d489a", 1);
+        REGISTERED_TYPE("XGStand1Perc", "Yamaha XG Standard 1 Percussion", "4c094420-0a8e-4dfa-b315-2bdb516d489a", 1);
 
         XgStandard1PercussionSet(const bw_music::BuiltInPercussionInstruments& builtInInstruments);
     };

--- a/Plugins/Smf/Plugin/gmSpec.hpp
+++ b/Plugins/Smf/Plugin/gmSpec.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <BabelWiresLib/Types/Enum/enumWithCppEnum.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Instance/enumTypeInstance.hpp>
 #include <BabelWiresLib/Instance/instance.hpp>
 
@@ -23,7 +23,7 @@ namespace smf {
     /// Carries the enum of GM Spec values.
     class GMSpecType : public babelwires::EnumType {
       public:
-        PRIMITIVE_TYPE("GMSpec", "GM Specification", "4dc2566d-1be8-468b-9aa0-2f4d63344a13", 1);
+        REGISTERED_TYPE("GMSpec", "GM Specification", "4dc2566d-1be8-468b-9aa0-2f4d63344a13", 1);
         GMSpecType();
 
         ENUM_DEFINE_CPP_ENUM(GM_SPEC_VALUES);

--- a/Plugins/Smf/Plugin/midiChannel.hpp
+++ b/Plugins/Smf/Plugin/midiChannel.hpp
@@ -7,14 +7,14 @@
  **/
 #pragma once
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Int/intType.hpp>
 
 namespace smf {
     /// An int type constrained to the legal range of a MIDI channel (0-15).
     class MidiChannel : public babelwires::IntType {
       public:
-        PRIMITIVE_TYPE("MidiChannel", "MIDI Channel", "85f19ba3-f5be-4c81-9632-9227f85baa4e", 1);
+        REGISTERED_TYPE("MidiChannel", "MIDI Channel", "85f19ba3-f5be-4c81-9632-9227f85baa4e", 1);
         MidiChannel();
     };
 } // namespace smf

--- a/Plugins/Smf/Plugin/midiMetadata.hpp
+++ b/Plugins/Smf/Plugin/midiMetadata.hpp
@@ -18,7 +18,7 @@
 namespace smf {
     class MidiMetadata : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("midiMetadata", "MIDI Metadata", "5032054f-d1b7-4cb4-8bac-2de60a1bc078", 1);
+        REGISTERED_TYPE("midiMetadata", "MIDI Metadata", "5032054f-d1b7-4cb4-8bac-2de60a1bc078", 1);
 
         MidiMetadata();
 

--- a/Plugins/Smf/Plugin/midiTrackAndChannel.hpp
+++ b/Plugins/Smf/Plugin/midiTrackAndChannel.hpp
@@ -11,7 +11,7 @@
 #include <Plugins/Smf/Plugin/smfCommon.hpp>
 
 #include <BabelWiresLib/Instance/instance.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
 #include <MusicLib/Types/Track/trackInstance.hpp>
@@ -36,7 +36,7 @@ namespace smf {
     /// the smaller became the larger.
     class MidiTrackAndChannel : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("TrackChannel", "Track and Channel", "5e9b395c-ec13-4bdb-9b2b-b060ba7fb707", 1);
+        REGISTERED_TYPE("TrackChannel", "Track and Channel", "5e9b395c-ec13-4bdb-9b2b-b060ba7fb707", 1);
         MidiTrackAndChannel();
 
         static babelwires::ShortId getTrackIdFromChannel(unsigned int channel);

--- a/Plugins/Smf/Plugin/midiTrackAndChannelArray.hpp
+++ b/Plugins/Smf/Plugin/midiTrackAndChannelArray.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <BabelWiresLib/ValueTree/valueTreeNode.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Array/arrayType.hpp>
 #include <Plugins/Smf/Plugin/midiTrackAndChannel.hpp>
 
@@ -17,7 +17,7 @@ namespace smf {
     // TODO: Just use a type constructor for this rather than a C++ class?
     class MidiTrackAndChannelArray : public babelwires::ArrayType {
       public:
-        PRIMITIVE_TYPE("MidiTrackArray", "MIDI Track and Channels", "b5462658-be68-4570-b0a5-d2dcb03f4d8e", 1);
+        REGISTERED_TYPE("MidiTrackArray", "MIDI Track and Channels", "b5462658-be68-4570-b0a5-d2dcb03f4d8e", 1);
         MidiTrackAndChannelArray();
     };
 } // namespace smf

--- a/Plugins/Smf/Plugin/recordOfMidiTracks.hpp
+++ b/Plugins/Smf/Plugin/recordOfMidiTracks.hpp
@@ -20,7 +20,7 @@ namespace smf {
 
     class RecordOfMidiTracks : public babelwires::RecordType {
       public:
-        PRIMITIVE_TYPE("recordOfTracks", "Tracks", "44244cf8-8a05-4071-91a3-af77514ee03b", 1);
+        REGISTERED_TYPE("recordOfTracks", "Tracks", "44244cf8-8a05-4071-91a3-af77514ee03b", 1);
 
         RecordOfMidiTracks();
 

--- a/Plugins/Smf/Plugin/smfSequence.hpp
+++ b/Plugins/Smf/Plugin/smfSequence.hpp
@@ -25,7 +25,7 @@ namespace smf {
     /// A type corresponding to the contents of a Standard MIDI file.
     class SmfSequence : public babelwires::RecordWithVariantsType {
       public:
-        PRIMITIVE_TYPE("SmfSeqType", "Standard MIDI File", "d4c70fb2-fb67-4e69-82ca-328ec242b0a8", 1);
+        REGISTERED_TYPE("SmfSeqType", "Standard MIDI File", "d4c70fb2-fb67-4e69-82ca-328ec242b0a8", 1);
         SmfSequence();
 
         DECLARE_INSTANCE_BEGIN(SmfSequence)


### PR DESCRIPTION
Adapt to a BabelWires change.